### PR TITLE
Remove non-existent versions from changelog.

### DIFF
--- a/crates/factorio-cli/CHANGELOG.md
+++ b/crates/factorio-cli/CHANGELOG.md
@@ -10,8 +10,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [0.3.0] - 2022-11-09
 
-## [0.2.0] - 2022-11-09
-
 ### Incompatible changes
 
 - There is a new subcommand `fct resolve-mods` that lists all dependencies of a
@@ -33,5 +31,4 @@ Earlier changes are documented in [`factorio-explorer`'s change log](../factorio
 <!-- next-url -->
 [Unreleased]: https://github.com/MForster/factorio-rust-tools/compare/factorio-cli-v0.3.0...HEAD
 [0.3.0]: https://github.com/MForster/factorio-rust-tools/compare/factorio-cli-v0.2.0...factorio-cli-v0.3.0
-[0.2.0]: https://github.com/MForster/factorio-rust-tools/compare/factorio-cli-v0.1.0...factorio-cli-v0.2.0
 [0.1.0]: https://github.com/MForster/factorio-rust-tools/compare/v0.5.1...factorio-cli-v0.1.0

--- a/crates/factorio-exporter/CHANGELOG.md
+++ b/crates/factorio-exporter/CHANGELOG.md
@@ -10,8 +10,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [0.8.0] - 2022-11-09
 
-## [0.7.0] - 2022-11-09
-
 ## [0.6.0] - 2022-11-05
 
 ### Incompatible changes
@@ -144,7 +142,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 <!-- next-url -->
 [Unreleased]: https://github.com/MForster/factorio-rust-tools/compare/factorio-exporter-v0.8.0...HEAD
 [0.8.0]: https://github.com/MForster/factorio-rust-tools/compare/factorio-exporter-v0.7.0...factorio-exporter-v0.8.0
-[0.7.0]: https://github.com/MForster/factorio-rust-tools/compare/factorio-exporter-v0.6.0...factorio-exporter-v0.7.0
 [0.6.0]: https://github.com/MForster/factorio-rust-tools/compare/v0.5.1...factorio-exporter-v0.6.0
 [0.5.1]: https://github.com/MForster/factorio-rust-tools/compare/v0.5.0...v0.5.1
 [0.5.0]: https://github.com/MForster/factorio-rust-tools/compare/v0.4.0...v0.5.0

--- a/crates/factorio-mod-api/CHANGELOG.md
+++ b/crates/factorio-mod-api/CHANGELOG.md
@@ -10,13 +10,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [0.2.0] - 2022-11-09
 
-## [0.1.0] - 2022-11-09
-
 ### New features
 
 - Add an initial implementation of a mod portal client.
 
 <!-- next-url -->
 [Unreleased]: https://github.com/MForster/factorio-rust-tools/compare/factorio-mod-api-v0.2.0...HEAD
-[0.2.0]: https://github.com/MForster/factorio-rust-tools/compare/factorio-mod-api-v0.1.0...factorio-mod-api-v0.2.0
-[0.1.0]: https://github.com/MForster/factorio-rust-tools/compare/factorio-cli-v0.1.0...factorio-mod-api-v0.1.0
+[0.2.0]: https://github.com/MForster/factorio-rust-tools/compare/factorio-mod-api-base...factorio-mod-api-v0.2.0


### PR DESCRIPTION
For some reason `cargo-release` skipped a version... :-(